### PR TITLE
Support use_cache parameter in APIs

### DIFF
--- a/spark_llm/llm_chain_with_cache.py
+++ b/spark_llm/llm_chain_with_cache.py
@@ -5,7 +5,7 @@ from langchain.callbacks.manager import Callbacks
 
 from spark_llm.cache import Cache
 
-SKIP_CACHE_LOOKUP_TAGS = ["SKIP_CACHE_LOOKUP"]
+SKIP_CACHE_TAGS = ["SKIP_CACHE"]
 
 
 class LLMChainWithCache(LLMChain):
@@ -28,7 +28,7 @@ class LLMChainWithCache(LLMChain):
     ) -> str:
         assert not args, "The chain expected no arguments"
         prompt_str = self.prompt.format_prompt(**kwargs).to_string()
-        cached_result = self.cache.lookup(prompt_str) if tags != SKIP_CACHE_LOOKUP_TAGS else None
+        cached_result = self.cache.lookup(prompt_str) if tags != SKIP_CACHE_TAGS else None
         if cached_result is not None:
             return cached_result
         result = super().run(*args, callbacks=callbacks, tags=tags, **kwargs)

--- a/spark_llm/llm_utils.py
+++ b/spark_llm/llm_utils.py
@@ -21,27 +21,27 @@ class LLMMethodWrapper:
         self.assistant = assistant
         self.df_instance = df_instance
 
-    def transform(self, desc: str, lookup_cache: bool = True) -> DataFrame:
+    def transform(self, desc: str, use_cache: bool = True) -> DataFrame:
         """
         Transform the DataFrame using the given description.
 
         Args:
             desc: A string description specifying the transformation.
-            lookup_cache: Indicates whether to utilize a cache for this method.
+            use_cache: Indicates whether to utilize a cache for this method.
                 If `True`, fetches cached data, if available.
                 If `False`, retrieves fresh data and updates cache.
 
         Returns:
             The transformed DataFrame.
         """
-        return self.assistant.transform_df(self.df_instance, desc, lookup_cache)
+        return self.assistant.transform_df(self.df_instance, desc, use_cache)
 
-    def explain(self, lookup_cache: bool = True) -> str:
+    def explain(self, use_cache: bool = True) -> str:
         """
         Explain the DataFrame.
 
         Args:
-            lookup_cache: Indicates whether to utilize a cache for this method.
+            use_cache: Indicates whether to utilize a cache for this method.
                 If `True`, fetches cached data, if available.
                 If `False`, retrieves fresh data and updates cache.
 
@@ -49,31 +49,31 @@ class LLMMethodWrapper:
             A string explanation of the DataFrame.
 
         """
-        return self.assistant.explain_df(self.df_instance, lookup_cache)
+        return self.assistant.explain_df(self.df_instance, use_cache)
 
-    def plot(self, desc: Optional[str] = None, lookup_cache: bool = True) -> None:
+    def plot(self, desc: Optional[str] = None, use_cache: bool = True) -> None:
         """
         Plot the DataFrame.
 
         Args:
             desc: A string description specifying the plot.
-            lookup_cache: Indicates whether to utilize a cache for this method.
+            use_cache: Indicates whether to utilize a cache for this method.
                 If `True`, fetches cached data, if available.
                 If `False`, retrieves fresh data and updates cache.
         """
-        return self.assistant.plot_df(self.df_instance, desc, lookup_cache)
+        return self.assistant.plot_df(self.df_instance, desc, use_cache)
 
-    def verify(self, desc: str, lookup_cache: bool = True) -> None:
+    def verify(self, desc: str, use_cache: bool = True) -> None:
         """
         Verify the DataFrame using the given description.
 
         Args:
             desc: A string description specifying what to verify in the DataFrame.
-            lookup_cache: Indicates whether to utilize a cache for this method.
+            use_cache: Indicates whether to utilize a cache for this method.
                 If `True`, fetches cached data, if available.
                 If `False`, retrieves fresh data and updates cache.
         """
-        return self.assistant.verify_df(self.df_instance, desc, lookup_cache)
+        return self.assistant.verify_df(self.df_instance, desc, use_cache)
 
 
 class LLMUtils:

--- a/spark_llm/spark_llm_assistant.py
+++ b/spark_llm/spark_llm_assistant.py
@@ -14,7 +14,7 @@ from tiktoken import Encoding
 
 from spark_llm.cache import Cache
 from spark_llm.code_logger import CodeLogger
-from spark_llm.llm_chain_with_cache import LLMChainWithCache, SKIP_CACHE_LOOKUP_TAGS
+from spark_llm.llm_chain_with_cache import LLMChainWithCache, SKIP_CACHE_TAGS
 from spark_llm.prompt import (
     SEARCH_PROMPT,
     SQL_PROMPT,
@@ -169,17 +169,17 @@ class SparkLLMAssistant:
             tokens = tokens[:max_tokens]
         return self._encoding.decode(tokens)
 
-    def _get_url_from_search_tool(self, desc: str, columns: Optional[List[str]], lookup_cache: bool) -> str:
+    def _get_url_from_search_tool(self, desc: str, columns: Optional[List[str]], use_cache: bool) -> str:
         search_result = self._web_search_tool(desc)
         search_columns_hint = self._generate_search_prompt(columns)
         # Run the LLM chain to pick the best search result
-        tags = self._get_tags(lookup_cache)
+        tags = self._get_tags(use_cache)
         return self._search_llm_chain.run(
            tags=tags, query=desc, search_results=search_result, columns={search_columns_hint}
         )
 
     def _create_dataframe_with_llm(
-            self, text: str, desc: str, columns: Optional[List[str]], lookup_cache: bool
+            self, text: str, desc: str, columns: Optional[List[str]], use_cache: bool
     ) -> DataFrame:
         clean_text = " ".join(text.split())
         web_content = self._trim_text_from_end(
@@ -189,7 +189,7 @@ class SparkLLMAssistant:
         sql_columns_hint = self._generate_sql_prompt(columns)
 
         # Run the LLM chain to get an ingestion SQL query
-        tags = self._get_tags(lookup_cache)
+        tags = self._get_tags(use_cache)
         llm_result = self._sql_llm_chain.run(
             tags=tags, query=desc, web_content=web_content, columns=sql_columns_hint
         )
@@ -215,24 +215,24 @@ class SparkLLMAssistant:
 
         return trimmed_plan
 
-    def _get_df_explain(self, df: DataFrame, lookup_cache: bool) -> str:
+    def _get_df_explain(self, df: DataFrame, use_cache: bool) -> str:
         raw_analyzed_str = df._jdf.queryExecution().analyzed().toString()
-        tags = self._get_tags(lookup_cache)
+        tags = self._get_tags(use_cache)
         return self._explain_chain.run(tags=tags, input=self._trim_hash_id(raw_analyzed_str))
 
-    def _get_tags(self, lookup_cache: bool) -> Optional[List[str]]:
-        if self._enable_cache and not lookup_cache:
-            return SKIP_CACHE_LOOKUP_TAGS
+    def _get_tags(self, use_cache: bool) -> Optional[List[str]]:
+        if self._enable_cache and not use_cache:
+            return SKIP_CACHE_TAGS
         return None
 
-    def create_df(self, desc: str, columns: Optional[List[str]] = None, lookup_cache: bool = True) -> DataFrame:
+    def create_df(self, desc: str, columns: Optional[List[str]] = None, use_cache: bool = True) -> DataFrame:
         """
         Create a Spark DataFrame by querying an LLM from web search result.
 
         :param desc: the description of the result DataFrame, which will be used for
                      web searching
         :param columns: the expected column names in the result DataFrame
-        :param lookup_cache: If `True`, fetches cached data, if available. If `False`, retrieves fresh data and updates cache.
+        :param use_cache: If `True`, fetches cached data, if available. If `False`, retrieves fresh data and updates cache.
 
         :return: a Spark DataFrame
         """
@@ -240,7 +240,7 @@ class SparkLLMAssistant:
         is_url = self._is_http_or_https_url(url)
         # If the input is not a valid URL, use search tool to get the dataset.
         if not is_url:
-            url = self._get_url_from_search_tool(desc, columns, lookup_cache)
+            url = self._get_url_from_search_tool(desc, columns, use_cache)
 
         self.log(f"Parsing URL: {url}\n")
         try:
@@ -257,22 +257,22 @@ class SparkLLMAssistant:
         # If the input is a URL link, use the title of web page as the dataset's description.
         if is_url:
             desc = soup.title.string
-        return self._create_dataframe_with_llm(soup.get_text(), desc, columns, lookup_cache)
+        return self._create_dataframe_with_llm(soup.get_text(), desc, columns, use_cache)
 
-    def transform_df(self, df: DataFrame, desc: str, lookup_cache: bool = True) -> DataFrame:
+    def transform_df(self, df: DataFrame, desc: str, use_cache: bool = True) -> DataFrame:
         """
         This method applies a transformation to a provided Spark DataFrame, the specifics of which are determined by the 'desc' parameter.
 
         :param df: The Spark DataFrame that is to be transformed.
         :param desc: A natural language string that outlines the specific transformation to be applied on the DataFrame.
-        :param lookup_cache: If `True`, fetches cached data, if available. If `False`, retrieves fresh data and updates cache.
+        :param use_cache: If `True`, fetches cached data, if available. If `False`, retrieves fresh data and updates cache.
 
         :return: Returns a new Spark DataFrame that is the result of applying the specified transformation on the input DataFrame.
         """
         temp_view_name = "temp_view_for_transform"
         df.createOrReplaceTempView(temp_view_name)
         schema_str = self._get_df_schema(df)
-        tags=self._get_tags(lookup_cache)
+        tags=self._get_tags(use_cache)
         llm_result = self._transform_chain.run(
             tags=tags, view_name=temp_view_name, columns=schema_str, desc=desc
         )
@@ -281,16 +281,16 @@ class SparkLLMAssistant:
         self.log(f"SQL query for the transform:\n{formatted_sql_query}")
         return self._spark.sql(sql_query)
 
-    def explain_df(self, df: DataFrame, lookup_cache: bool = True) -> str:
+    def explain_df(self, df: DataFrame, use_cache: bool = True) -> str:
         """
         This method generates a natural language explanation of the SQL plan of the input Spark DataFrame.
 
         :param df: The Spark DataFrame to be explained.
-        :param lookup_cache: If `True`, fetches cached data, if available. If `False`, retrieves fresh data and updates cache.
+        :param use_cache: If `True`, fetches cached data, if available. If `False`, retrieves fresh data and updates cache.
 
         :return: A string explanation of the DataFrame's SQL plan, detailing what the DataFrame is intended to retrieve.
         """
-        explain_result = self._get_df_explain(df, lookup_cache)
+        explain_result = self._get_df_explain(df, use_cache)
         # If there is code block in the explain result, ignore it.
         if "```" in explain_result:
             summary = explain_result.split("```")[-1]
@@ -298,13 +298,13 @@ class SparkLLMAssistant:
         else:
             return explain_result
 
-    def plot_df(self, df: DataFrame, desc: Optional[str] = None, lookup_cache: bool = True) -> None:
+    def plot_df(self, df: DataFrame, desc: Optional[str] = None, use_cache: bool = True) -> None:
         instruction = f"The purpose of the plot: {desc}" if desc is not None else ""
-        tags=self._get_tags(lookup_cache)
+        tags=self._get_tags(use_cache)
         response = self._plot_chain.run(
             tags=tags,
             columns=self._get_df_schema(df),
-            explain=self._get_df_explain(df, lookup_cache),
+            explain=self._get_df_explain(df, use_cache),
             instruction=instruction,
         )
         self.log(response)
@@ -312,15 +312,15 @@ class SparkLLMAssistant:
         for code in codeblocks:
             exec(code)
 
-    def verify_df(self, df: DataFrame, desc: str, lookup_cache: bool = True) -> None:
+    def verify_df(self, df: DataFrame, desc: str, use_cache: bool = True) -> None:
         """
         This method creates and runs test cases for the provided PySpark dataframe transformation function.
 
         :param df: The Spark DataFrame to be verified
         :param desc: A description of the expectation to be verified
-        :param lookup_cache: If `True`, fetches cached data, if available. If `False`, retrieves fresh data and updates cache.
+        :param use_cache: If `True`, fetches cached data, if available. If `False`, retrieves fresh data and updates cache.
         """
-        tags = self._get_tags(lookup_cache)
+        tags = self._get_tags(use_cache)
         llm_output = self._verify_chain.run(tags=tags, df=df, desc=desc)
         formatted_code = CodeLogger.colorize_code(llm_output, "python")
         self.log(f"Generated code:\n{formatted_code}")


### PR DESCRIPTION
For all the APIs in SparkLLMAssistant, add a new parameter `use_cache` which indicates whether to utilize a cache for this method call.
This is very useful when a user get a bad response from LLM.