### PR TITLE
Make PySpark AI Spark Connect Compatible

### DIFF
--- a/tests/test_spark_llm_assistant.py
+++ b/tests/test_spark_llm_assistant.py
@@ -183,5 +183,15 @@ class CacheRetrievalTestCase(SparkTestCase):
         self.assertEqual(udf1("test"), udf2("test"))
 
 
+class SparkAnalysisTest(SparkTestCase):
+
+    def test_analysis_handling(self):
+        self.assistant = SparkAI()
+        df = self.spark.range(100).groupBy("id").count()
+        left = self.assistant._parse_explain_string(df)
+        right = df._jdf.queryExecution().analyzed().toString()
+        self.assertEqual(left, right)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This patch removes the usage of `_jdf` and replaces it with the necessary logic that is necessary to make it Spark Connect compatible. In addition, it fixes the patching of the DataFrame class and patches the Spark Connect class as well.

```
from pyspark_ai import SparkAI

spark = SparkSession.builder.remote("sc://localhost).getOrCreate()
spark_ai = SparkAI(spark_session=spark)
spark_ai.activate()

spark.range(100).ai.transform("count the rows")
```