### PR TITLE
[WIP] Retry generating Python code for `plot` and `verify`

### DIFF
--- a/pyspark_ai/ai_utils.py
+++ b/pyspark_ai/ai_utils.py
@@ -137,11 +137,13 @@ class AIUtils:
     def retry_execution(callback, max_tries=3):
         tries = 0
         last_exception = None
+        error_messages = []
         while max_tries > tries:
             try:
-                return callback()
+                return callback(error_messages)
             except Exception as e:
                 last_exception = e
+                error_messages.append(str(e))
                 tries += 1
         raise Exception(
             "Could not evaluate Python code after multiple attempts"

--- a/pyspark_ai/ai_utils.py
+++ b/pyspark_ai/ai_utils.py
@@ -132,3 +132,17 @@ class AIUtils:
             if text.startswith("`") and text.endswith("`"):
                 return [text.strip("`")]
             return [text]
+
+    @staticmethod
+    def retry_execution(callback, max_tries=3):
+        tries = 0
+        last_exception = None
+        while max_tries > tries:
+            try:
+                return callback()
+            except Exception as e:
+                last_exception = e
+                tries += 1
+        raise Exception(
+            "Could not evaluate Python code after multiple attempts"
+        ) from last_exception

--- a/tests/test_ai_utils.py
+++ b/tests/test_ai_utils.py
@@ -62,5 +62,25 @@ SELECT c FROM d;
         self.assertEqual(AIUtils.extract_code_blocks(text), ["SELECT a FROM b;", "SELECT c FROM d;"])
 
 
+class TestRetryExecution(unittest.TestCase):
+
+    def test_retry_execution(self):
+        counter = [0]
+
+        def failing_function():
+            counter[0] += 1
+            if counter[0] < 3:
+                raise ValueError("This function is supposed to fail!")
+            return "Success"
+
+        try:
+            result = AIUtils.retry_execution(failing_function)
+        except Exception as e:
+            self.fail(f"Caught exception: {e}")
+
+        self.assertEqual(result, "Success", "Function did not succeed after retries")
+        self.assertEqual(counter[0], 3, "Function was not retried the expected number of times")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_ai_utils.py
+++ b/tests/test_ai_utils.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import List
 
 from pyspark_ai.ai_utils import AIUtils
 
@@ -67,7 +68,7 @@ class TestRetryExecution(unittest.TestCase):
     def test_retry_execution(self):
         counter = [0]
 
-        def failing_function():
+        def failing_function(error_messages: List[str]):
             counter[0] += 1
             if counter[0] < 3:
                 raise ValueError("This function is supposed to fail!")


### PR DESCRIPTION
## Change
Retry generating Python code (with error messages feedbacked) for both `plot` and `verify` methods if execution fails.

We may apply the retry mechanism to other APIs in follow-ups.

## Test
Unit test and manual tests.

