### PR TITLE
Exclude SimilarValueTool By Default

### DIFF
--- a/pyspark_ai/pyspark_ai.py
+++ b/pyspark_ai/pyspark_ai.py
@@ -126,13 +126,21 @@ class SparkAI:
         return LLMChainWithCache(llm=self._llm, prompt=prompt, cache=self._cache)
 
     def _create_sql_agent(self):
-        tools = [
-            QuerySparkSQLTool(spark=self._spark),
-            QueryValidationTool(spark=self._spark),
-            SimilarValueTool(
-                spark=self._spark, vector_store_dir=self._vector_store_dir
-            ),
-        ]
+        # exclude SimilarValueTool if vector_store_dir not configured
+        tools = (
+            [
+                QuerySparkSQLTool(spark=self._spark),
+                QueryValidationTool(spark=self._spark),
+                SimilarValueTool(
+                    spark=self._spark, vector_store_dir=self._vector_store_dir
+                ),
+            ]
+            if self._vector_store_dir
+            else [
+                QuerySparkSQLTool(spark=self._spark),
+                QueryValidationTool(spark=self._spark),
+            ]
+        )
         agent = ReActSparkSQLAgent.from_llm_and_tools(
             llm=self._llm, tools=tools, verbose=True
         )

--- a/tests/test_ai_tools.py
+++ b/tests/test_ai_tools.py
@@ -1,0 +1,38 @@
+import unittest
+
+from pyspark_ai.pyspark_ai import SparkAI
+from pyspark_ai.tool import QuerySparkSQLTool, QueryValidationTool, SimilarValueTool
+
+
+class TestToolsInit(unittest.TestCase):
+    def test_exclude_similar_value_tool(self):
+        """Test that SimilarValueTool is excluded by default"""
+        spark_ai = SparkAI()
+        agent = spark_ai._create_sql_agent()
+        self.assertEqual(
+            agent.tools,
+            [
+                QuerySparkSQLTool(spark=spark_ai._spark),
+                QueryValidationTool(spark=spark_ai._spark),
+            ],
+        )
+
+    def test_include_similar_value_tool(self):
+        """Test that SimilarValueTool is included when vector_store_dir is specified"""
+        vector_store_dir = "temp/"
+        spark_ai = SparkAI(vector_store_dir=vector_store_dir)
+        agent = spark_ai._create_sql_agent()
+        self.assertEqual(
+            agent.tools,
+            [
+                QuerySparkSQLTool(spark=spark_ai._spark),
+                QueryValidationTool(spark=spark_ai._spark),
+                SimilarValueTool(
+                    spark=spark_ai._spark, vector_store_dir=vector_store_dir
+                ),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ai_tools.py
+++ b/tests/test_ai_tools.py
@@ -1,13 +1,21 @@
 import unittest
+from unittest.mock import MagicMock
+from langchain.base_language import BaseLanguageModel
+from pyspark.sql import SparkSession
 
 from pyspark_ai.pyspark_ai import SparkAI
 from pyspark_ai.tool import QuerySparkSQLTool, QueryValidationTool, SimilarValueTool
 
 
 class TestToolsInit(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.spark = SparkSession.builder.getOrCreate()
+        cls.llm_mock = MagicMock(spec=BaseLanguageModel)
+
     def test_exclude_similar_value_tool(self):
         """Test that SimilarValueTool is excluded by default"""
-        spark_ai = SparkAI()
+        spark_ai = SparkAI(llm=self.llm_mock, spark_session=self.spark)
         agent = spark_ai._create_sql_agent()
         self.assertEqual(
             agent.tools,
@@ -20,7 +28,11 @@ class TestToolsInit(unittest.TestCase):
     def test_include_similar_value_tool(self):
         """Test that SimilarValueTool is included when vector_store_dir is specified"""
         vector_store_dir = "temp/"
-        spark_ai = SparkAI(vector_store_dir=vector_store_dir)
+        spark_ai = SparkAI(
+            llm=self.llm_mock,
+            spark_session=self.spark,
+            vector_store_dir=vector_store_dir,
+        )
         agent = spark_ai._create_sql_agent()
         self.assertEqual(
             agent.tools,


### PR DESCRIPTION
This PR excludes `SimilarValueTool` by default, if `vector_store_dir` is not configured. The change is made to ensure that we do not store vector db in-memory, as this could cause OOM.