### PR TITLE
Add CNAME file for doc website

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+pyspark.ai


### PR DESCRIPTION
As per https://www.mkdocs.org/user-guide/deploying-your-docs/#custom-domains, we need this for custom domain.