### PR TITLE
Change navbar color to match PySpark docs

### DIFF
--- a/docs/stylesheets/extra_css.css
+++ b/docs/stylesheets/extra_css.css
@@ -1,0 +1,4 @@
+:root {
+  --md-primary-fg-color: #1B5162;
+  --md-accent-fg-color: #1B5162;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,9 @@ theme:
   logo: _static/english-sdk-spark-reverse.svg
   features:
     - content.code.copy
+  palette:
+    primary: custom
+    accent: custom
 
 repo_url: https://github.com/pyspark-ai/pyspark-ai/
 
@@ -29,3 +32,6 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+
+extra_css:
+  - stylesheets/extra_css.css


### PR DESCRIPTION
This PR updates the docs website navbar background color to match the PySpark docs theme:

<img width="1293" alt="Screenshot 2023-10-03 at 9 39 19 AM" src="https://github.com/pyspark-ai/pyspark-ai/assets/68875504/85f5dc42-c424-43e4-9e4a-dd7839ae58ab">
