### PR TITLE
Fix syntax error in .github/workflows/website.yml

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,10 +1,12 @@
 name: publish website 
+
 on:
   push:
     branches:
       - master
-  paths:
-    - 'docs/**'
+    paths:
+      - 'docs/**'
+
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
There's a small mistake in the GitHub Actions workflow file `.github/workflows/website.yml`. The paths filter should be nested under each event under on, not directly under on. 
https://github.com/pyspark-ai/pyspark-ai/actions/runs/6396235565:
```
[Error: .github#L1](https://github.com/pyspark-ai/pyspark-ai/commit/d0d490220343ddea7a6d02932ff26e700e6b6400#annotation_14621674381)
Invalid type for `on`
```
This PR is to fix it