### PR TITLE
Add explanation of when to use SUM

### DIFF
--- a/pyspark_ai/prompt.py
+++ b/pyspark_ai/prompt.py
@@ -144,7 +144,7 @@ SPARK_SQL_PREFIX = """You are an assistant for writing professional Spark SQL qu
 Given a question, you need to write a Spark SQL query to answer the question. The result is ALWAYS a Spark SQL query.
 Always use the tool similar_value to find the correct filter value format, unless it's obvious.
 Use the COUNT SQL function when the query asks for total number of some non-countable column.
-Otherwise, use the SUM SQL function to accumulate the total number of countable column values."""
+Use the SUM SQL function to accumulate the total number of countable column values."""
 
 SPARK_SQL_PROMPT = PromptTemplate.from_examples(
     examples=SPARK_SQL_EXAMPLES,

--- a/pyspark_ai/prompt.py
+++ b/pyspark_ai/prompt.py
@@ -143,7 +143,8 @@ Write a Spark SQL query to retrieve the following from view `{view_name}`: {desc
 SPARK_SQL_PREFIX = """You are an assistant for writing professional Spark SQL queries. 
 Given a question, you need to write a Spark SQL query to answer the question. The result is ALWAYS a Spark SQL query.
 Always use the tool similar_value to find the correct filter value format, unless it's obvious.
-Use the COUNT SQL function when the query asks for total number of some non-countable column."""
+Use the COUNT SQL function when the query asks for total number of some non-countable column.
+Otherwise, use the SUM SQL function to accumulate the total number of countable column values."""
 
 SPARK_SQL_PROMPT = PromptTemplate.from_examples(
     examples=SPARK_SQL_EXAMPLES,


### PR DESCRIPTION
This PR adds an explanation of when to use SUM vs. COUNT in the transform prompt. This fixes examples like the following:

```
Question: How many home wins occured win the road games are larger than 3.0 but road win percentage is .000?
Expected query: SELECT `(Home wins)` FROM `1-1409106-2` WHERE `Road Win Pct.` = '.000' AND `ROAD games` > 3.0
Actual query: select count(`home wins`) from `spark_ai_temp_view_1928808132` where `road games` > 3.0 and `road win pct.` = '.000'
Expected result: ['0.0']
Actual result: ['1']
```