### PR TITLE
Fix regression on the plotting API when verbose is False

### DIFF
--- a/pyspark_ai/python_executor.py
+++ b/pyspark_ai/python_executor.py
@@ -21,7 +21,7 @@ class PythonExecutor(LLMChain):
 
     df: DataFrame
     cache: Cache = None
-    logger: CodeLogger
+    logger: CodeLogger = None
     max_retries: int = 3
 
     def run(

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -214,7 +214,7 @@ class EndToEndTestCase(unittest.TestCase):
         assert abs(spark_results["stddev"] - numpy_stddev) / numpy_stddev <= 0.05
 
     def test_plot(self):
-        flight_df = self.spark_ai._spark.read.option("header", "true").csv("data/2011_february_aa_flight_paths.csv")
+        flight_df = self.spark_ai._spark.read.option("header", "true").csv("tests/data/2011_february_aa_flight_paths.csv")
         # The following plotting will probably fail on the first run with error:
         #     'DataFrame' object has no attribute 'date'
         code = flight_df.ai.plot("Boxplot summarizing the range of starting latitudes for all AA flights in February 2011.")


### PR DESCRIPTION
Fix the following regression from https://github.com/pyspark-ai/pyspark-ai/pull/159:
```
>>> df.ai.plot("Bar plot of the top 5 most populous cities")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/xinrong.meng/pyspark-ai/pyspark_ai/ai_utils.py", line 66, in plot
    return self.spark_ai.plot_df(self.df_instance, desc, cache)
  File "/Users/xinrong.meng/pyspark-ai/pyspark_ai/pyspark_ai.py", line 525, in plot_df
    plot_chain = PythonExecutor(
  File "/opt/miniconda3/envs/eng_dev/lib/python3.9/site-packages/langchain/load/serializable.py", line 74, in __init__
    super().__init__(**kwargs)
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for PythonExecutor
logger
  none is not an allowed value (type=type_error.none.not_allowed)
```

Also, this PR fixes the file location in the end_to_end test case