### PR TITLE
DataFrame transform: use simple code generation when LLM is not GPT-4

### DIFF
--- a/pyspark_ai/prompt.py
+++ b/pyspark_ai/prompt.py
@@ -50,7 +50,7 @@ sql_question1 = """QUESTION: Given a Spark temp view `spark_ai_temp_view_14kjd0`
 ```
 Write a Spark SQL query to retrieve from view `spark_ai_temp_view_14kjd0`: Find the mountain located in Japan."""
 
-sql_answer1 = "Final Answer: SELECT `a` FROM `spark_ai_temp_view_14kjd0` WHERE `c` = 'Japan'"
+sql_answer1 = "SELECT `a` FROM `spark_ai_temp_view_14kjd0` WHERE `c` = 'Japan'"
 
 sql_question2 = """QUESTION: Given a Spark temp view `spark_ai_temp_view_12qcl3` with the following columns:
 ```
@@ -60,7 +60,7 @@ Birthday: string
 Write a Spark SQL query to retrieve from view `spark_ai_temp_view_12qcl3`: What is the total number of students with the birthday January 1, 2006?
 """
 
-sql_answer2 = "Final Answer: SELECT COUNT(`Student`) FROM `spark_ai_temp_view_12qcl3` WHERE `Birthday` = 'January 1, 2006'"
+sql_answer2 = "SELECT COUNT(`Student`) FROM `spark_ai_temp_view_12qcl3` WHERE `Birthday` = 'January 1, 2006'"
 
 spark_sql_shared_example_1_prefix = f"""{sql_question1}
 Thought: The column names are non-descriptive, but from the sample values I see that column `a` contains mountains
@@ -71,7 +71,7 @@ spark_sql_shared_example_1_suffix = f"""Action: query_validation
 Action Input: SELECT `a` FROM `spark_ai_temp_view_14kjd0` WHERE `c` = 'Japan'
 Observation: OK
 Thought:I now know the final answer.
-{sql_answer1}"""
+Final Answer: {sql_answer1}"""
 
 spark_sql_no_vector_example_1 = (
     spark_sql_shared_example_1_prefix + spark_sql_shared_example_1_suffix
@@ -97,7 +97,7 @@ spark_sql_no_vector_example_2 = (
 Action Input: SELECT COUNT(`Student`) FROM `spark_ai_temp_view_12qcl3` WHERE `Birthday` = 'January 1, 2006'
 Observation: OK
 Thought: I now know the final answer.
-{sql_answer2}"""
+Final Answer: {sql_answer2}"""
 )
 
 spark_sql_vector_example_2 = (
@@ -217,8 +217,8 @@ SPARK_SQL_PROMPT_NO_VECTOR_SEARCH = PromptTemplate.from_examples(
 )
 
 SQL_CHAIN_EXAMPLES = [
-    sql_question1 + "\n" + sql_answer1,
-    sql_question2 + "\n" + sql_answer2,
+    sql_question1 + f"\nAnswer:\n```{sql_answer1}```",
+    sql_question2 + f"\nAnswer:\n```{sql_answer2}```",
 ]
 
 SQL_CHAIN_PROMPT = PromptTemplate.from_examples(

--- a/pyspark_ai/prompt.py
+++ b/pyspark_ai/prompt.py
@@ -41,23 +41,37 @@ SQL_PROMPT = PromptTemplate(
 )
 
 # spark SQL few shot examples
-spark_sql_shared_example_1_prefix = """QUESTION: Given a Spark temp view `spark_ai_temp_view_14kjd0` with the following sample vals,
+sql_question1 = """QUESTION: Given a Spark temp view `spark_ai_temp_view_14kjd0` with the following sample vals,
     in the format (column_name: type, [sample_value_1, sample_value_2...]):
 ```
 (a: string, [Kongur Tagh, Grossglockner])
 (b: int, [7649, 3798])
 (c: string, [China, Austria])
 ```
-Write a Spark SQL query to retrieve from view `spark_ai_temp_view_14kjd0`: Find the mountain located in Japan.
+Write a Spark SQL query to retrieve from view `spark_ai_temp_view_14kjd0`: Find the mountain located in Japan."""
+
+sql_answer1 = "Final Answer: SELECT `a` FROM `spark_ai_temp_view_14kjd0` WHERE `c` = 'Japan'"
+
+sql_question2 = """QUESTION: Given a Spark temp view `spark_ai_temp_view_12qcl3` with the following columns:
+```
+Student: string
+Birthday: string
+```
+Write a Spark SQL query to retrieve from view `spark_ai_temp_view_12qcl3`: What is the total number of students with the birthday January 1, 2006?
+"""
+
+sql_answer2 = "Final Answer: SELECT COUNT(`Student`) FROM `spark_ai_temp_view_12qcl3` WHERE `Birthday` = 'January 1, 2006'"
+
+spark_sql_shared_example_1_prefix = f"""{sql_question1}
 Thought: The column names are non-descriptive, but from the sample values I see that column `a` contains mountains
 and column `c` contains countries. So, I will filter on column `c` for 'Japan' and column `a` for the mountain.
 I will use = rather than "like" in my SQL query because I need an exact match."""
 
-spark_sql_shared_example_1_suffix = """Action: query_validation
+spark_sql_shared_example_1_suffix = f"""Action: query_validation
 Action Input: SELECT `a` FROM `spark_ai_temp_view_14kjd0` WHERE `c` = 'Japan'
 Observation: OK
 Thought:I now know the final answer.
-Final Answer: SELECT `a` FROM `spark_ai_temp_view_14kjd0` WHERE `c` = 'Japan'"""
+{sql_answer1}"""
 
 spark_sql_no_vector_example_1 = (
     spark_sql_shared_example_1_prefix + spark_sql_shared_example_1_suffix
@@ -74,21 +88,16 @@ Thought: The correct `c` filter should be 'Japan' because it is semantically clo
     + spark_sql_shared_example_1_suffix
 )
 
-spark_sql_shared_example_2_prefix = """QUESTION: Given a Spark temp view `spark_ai_temp_view_12qcl3` with the following columns:
-```
-Student: string
-Birthday: string
-```
-Write a Spark SQL query to retrieve from view `spark_ai_temp_view_12qcl3`: What is the total number of students with the birthday January 1, 2006?
+spark_sql_shared_example_2_prefix = f"""{sql_question2}
 Thought: The keyword 'January 1, 2006' is most similar to the sample values in the `Birthday` column."""
 
 spark_sql_no_vector_example_2 = (
     spark_sql_shared_example_2_prefix
-    + """Action: query_validation
+    + f"""Action: query_validation
 Action Input: SELECT COUNT(`Student`) FROM `spark_ai_temp_view_12qcl3` WHERE `Birthday` = 'January 1, 2006'
 Observation: OK
 Thought: I now know the final answer.
-Final Answer: SELECT COUNT(`Student`) FROM `spark_ai_temp_view_12qcl3` WHERE `Birthday` = 'January 1, 2006'"""
+{sql_answer2}"""
 )
 
 spark_sql_vector_example_2 = (
@@ -171,7 +180,9 @@ It's very important to ONLY use the verbatim column_name in your resulting SQL q
 {sample_vals}
 
 Write a Spark SQL query to retrieve the following from view `{view_name}`: {desc}
-{agent_scratchpad}"""
+"""
+
+SPARK_SQL_SUFFIX_FOR_AGENT = SPARK_SQL_SUFFIX + "\n{agent_scratchpad}"
 
 SPARK_SQL_PREFIX = """You are an assistant for writing professional Spark SQL queries. 
 Given a question, you need to write a Spark SQL query to answer the question. The result is ALWAYS a Spark SQL query.
@@ -181,7 +192,7 @@ Use the SUM SQL function to accumulate the total number of countable column valu
 
 SPARK_SQL_PROMPT_VECTOR_SEARCH = PromptTemplate.from_examples(
     examples=SPARK_SQL_EXAMPLES_VECTOR_SEARCH,
-    suffix=SPARK_SQL_SUFFIX,
+    suffix=SPARK_SQL_SUFFIX_FOR_AGENT,
     input_variables=[
         "view_name",
         "sample_vals",
@@ -194,7 +205,7 @@ SPARK_SQL_PROMPT_VECTOR_SEARCH = PromptTemplate.from_examples(
 
 SPARK_SQL_PROMPT_NO_VECTOR_SEARCH = PromptTemplate.from_examples(
     examples=SPARK_SQL_EXAMPLES_NO_VECTOR_SEARCH,
-    suffix=SPARK_SQL_SUFFIX,
+    suffix=SPARK_SQL_SUFFIX_FOR_AGENT,
     input_variables=[
         "view_name",
         "sample_vals",
@@ -205,6 +216,22 @@ SPARK_SQL_PROMPT_NO_VECTOR_SEARCH = PromptTemplate.from_examples(
     prefix=SPARK_SQL_PREFIX,
 )
 
+SQL_CHAIN_EXAMPLES = [
+    sql_question1 + "\n" + sql_answer1,
+    sql_question2 + "\n" + sql_answer2,
+]
+
+SQL_CHAIN_PROMPT = PromptTemplate.from_examples(
+    examples=SQL_CHAIN_EXAMPLES,
+    suffix=SPARK_SQL_SUFFIX,
+    input_variables=[
+        "view_name",
+        "sample_vals",
+        "comment",
+        "desc",
+    ],
+    prefix=SPARK_SQL_PREFIX,
+)
 
 EXPLAIN_PREFIX = """You are an Apache Spark SQL expert, who can summary what a dataframe retrieves. Given an analyzed
 query plan of a dataframe, you will

--- a/pyspark_ai/pyspark_ai.py
+++ b/pyspark_ai/pyspark_ai.py
@@ -139,6 +139,7 @@ class SparkAI:
                 prompt=SQL_CHAIN_PROMPT,
                 llm=self._llm,
                 logger=self._logger,
+                spark=self._spark,
             )
         return self._sql_chain
 
@@ -479,7 +480,11 @@ class SparkAI:
             )
         else:
             # Otherwise, generate the SQL query with a prompt with few-shot examples
-            chain =
+            return self.sql_chain.run(
+                view_name=temp_view_name,
+                sample_vals=sample_vals_str,
+                comment=comment,
+                desc=desc)
 
     def _get_transform_sql_query(self, df: DataFrame, desc: str, cache: bool) -> str:
         temp_view_name = random_view_name(df)
@@ -508,13 +513,13 @@ class SparkAI:
                 self.log(CodeLogger.colorize_code(cached_result, "sql"))
                 return replace_view_name(cached_result, temp_view_name)
             else:
-                sql_query = self._get_transform_sql_query_from_agent(
+                sql_query = self._get_sql_query(
                     temp_view_name, sample_vals_str, comment, desc
                 )
                 self._cache.update(key=cache_key, val=canonize_string(sql_query))
                 return sql_query
         else:
-            return self._get_transform_sql_query_from_agent(
+            return self._get_sql_query(
                 temp_view_name, sample_vals_str, comment, desc
             )
 

--- a/pyspark_ai/pyspark_ai.py
+++ b/pyspark_ai/pyspark_ai.py
@@ -23,7 +23,8 @@ from pyspark_ai.prompt import (
     SEARCH_PROMPT,
     SQL_PROMPT,
     UDF_PROMPT,
-    VERIFY_PROMPT, SQL_CHAIN_PROMPT,
+    VERIFY_PROMPT,
+    SQL_CHAIN_PROMPT,
 )
 from pyspark_ai.python_executor import PythonExecutor
 from pyspark_ai.react_spark_sql_agent import ReActSparkSQLAgent
@@ -130,7 +131,6 @@ class SparkAI:
             return LLMChain(llm=self._llm, prompt=prompt)
 
         return LLMChainWithCache(llm=self._llm, prompt=prompt, cache=self._cache)
-
 
     @property
     def sql_chain(self):
@@ -484,7 +484,8 @@ class SparkAI:
                 view_name=temp_view_name,
                 sample_vals=sample_vals_str,
                 comment=comment,
-                desc=desc)
+                desc=desc,
+            )
 
     def _get_transform_sql_query(self, df: DataFrame, desc: str, cache: bool) -> str:
         temp_view_name = random_view_name(df)
@@ -519,9 +520,7 @@ class SparkAI:
                 self._cache.update(key=cache_key, val=canonize_string(sql_query))
                 return sql_query
         else:
-            return self._get_sql_query(
-                temp_view_name, sample_vals_str, comment, desc
-            )
+            return self._get_sql_query(temp_view_name, sample_vals_str, comment, desc)
 
     def transform_df(self, df: DataFrame, desc: str, cache: bool = True) -> DataFrame:
         """

--- a/pyspark_ai/pyspark_ai.py
+++ b/pyspark_ai/pyspark_ai.py
@@ -23,11 +23,12 @@ from pyspark_ai.prompt import (
     SEARCH_PROMPT,
     SQL_PROMPT,
     UDF_PROMPT,
-    VERIFY_PROMPT,
+    VERIFY_PROMPT, SQL_CHAIN_PROMPT,
 )
 from pyspark_ai.python_executor import PythonExecutor
 from pyspark_ai.react_spark_sql_agent import ReActSparkSQLAgent
 from pyspark_ai.search_tool_with_cache import SearchToolWithCache
+from pyspark_ai.spark_sql_chain import SparkSQLChain
 from pyspark_ai.temp_view_utils import (
     random_view_name,
     replace_view_name,
@@ -111,9 +112,8 @@ class SparkAI:
         self._vector_store_max_gb = vector_store_max_gb
         self._max_tokens_of_web_content = max_tokens_of_web_content
         self._search_llm_chain = self._create_llm_chain(prompt=SEARCH_PROMPT)
-        self._sql_llm_chain = self._create_llm_chain(prompt=SQL_PROMPT)
+        self._ingestion_chain = self._create_llm_chain(prompt=SQL_PROMPT)
         self._explain_chain = self._create_llm_chain(prompt=EXPLAIN_DF_PROMPT)
-        self._sql_agent = self._create_sql_agent()
         self._verify_chain = self._create_llm_chain(prompt=VERIFY_PROMPT)
         self._udf_chain = self._create_llm_chain(prompt=UDF_PROMPT)
         self._sample_rows_in_table_info = sample_rows_in_table_info
@@ -122,12 +122,31 @@ class SparkAI:
             self._logger = CodeLogger("spark_ai")
         else:
             self._logger = None
+        self._sql_agent = None
+        self._sql_chain = None
 
     def _create_llm_chain(self, prompt: BasePromptTemplate):
         if self._cache is None:
             return LLMChain(llm=self._llm, prompt=prompt)
 
         return LLMChainWithCache(llm=self._llm, prompt=prompt, cache=self._cache)
+
+
+    @property
+    def sql_chain(self):
+        if self._sql_chain is None:
+            self._sql_chain = SparkSQLChain(
+                prompt=SQL_CHAIN_PROMPT,
+                llm=self._llm,
+                logger=self._logger,
+            )
+        return self._sql_chain
+
+    @property
+    def sql_agent(self):
+        if self._sql_agent is not None:
+            self._sql_agent = self._create_sql_agent()
+        return self._sql_agent
 
     def _create_sql_agent(self):
         # exclude SimilarValueTool if vector_store_dir not configured
@@ -251,7 +270,7 @@ class SparkAI:
         # Run the LLM chain to get an ingestion SQL query
         tags = self._get_tags(cache)
         temp_view_name = random_view_name(web_content)
-        llm_result = self._sql_llm_chain.run(
+        llm_result = self._ingestion_chain.run(
             tags=tags,
             query=desc,
             web_content=web_content,
@@ -405,7 +424,7 @@ class SparkAI:
         comment: str,
         desc: str,
     ) -> str:
-        llm_result = self._sql_agent.run(
+        llm_result = self.sql_agent.run(
             view_name=temp_view_name,
             sample_vals=sample_vals_str,
             comment=comment,
@@ -445,6 +464,22 @@ class SparkAI:
             if len(comment) > 0:
                 return "which represents " + comment
         return ""
+
+    def _get_sql_query(
+        self,
+        temp_view_name: str,
+        sample_vals_str: str,
+        comment: str,
+        desc: str,
+    ) -> str:
+        # If LLM is ChatOpenAI instance and the model is GPT-4, use the ReActSparkSQLAgent to generate the SQL query
+        if isinstance(self._llm, ChatOpenAI) and self._llm.model_name == "gpt-4":
+            return self._get_transform_sql_query_from_agent(
+                temp_view_name, sample_vals_str, comment, desc
+            )
+        else:
+            # Otherwise, generate the SQL query with a prompt with few-shot examples
+            chain =
 
     def _get_transform_sql_query(self, df: DataFrame, desc: str, cache: bool) -> str:
         temp_view_name = random_view_name(df)

--- a/pyspark_ai/pyspark_ai.py
+++ b/pyspark_ai/pyspark_ai.py
@@ -145,7 +145,7 @@ class SparkAI:
 
     @property
     def sql_agent(self):
-        if self._sql_agent is not None:
+        if self._sql_agent is None:
             self._sql_agent = self._create_sql_agent()
         return self._sql_agent
 

--- a/pyspark_ai/spark_sql_chain.py
+++ b/pyspark_ai/spark_sql_chain.py
@@ -1,0 +1,70 @@
+from typing import Any, Optional, List
+
+from langchain.callbacks.base import Callbacks
+from langchain.chains import LLMChain
+from langchain.chat_models.base import BaseChatModel
+from langchain.schema import HumanMessage, BaseMessage
+from pyspark.sql import SparkSession
+from pyspark_ai.code_logger import CodeLogger
+
+from pyspark_ai.ai_utils import AIUtils
+
+
+class SparkSQLChain(LLMChain):
+    """
+    LLM Chain for generating SQL code for DataFrame transform.
+    It supports retrying if the generated query fails the SQL compiler.
+    """
+    spark: SparkSession
+    logger: CodeLogger = None
+    max_retries: int = 3
+
+    def run(
+        self,
+        *args: Any,
+        callbacks: Callbacks = None,
+        tags: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> str:
+        assert not args, "The chain expected no arguments"
+        # assert llm is an instance of BaseChatModel
+        assert isinstance(
+            self.llm, BaseChatModel
+        ), "The llm is not an instance of BaseChatModel"
+        prompt_str = self.prompt.format_prompt(**kwargs).to_string()
+        messages = [HumanMessage(content=prompt_str)]
+        return self._generate_code_with_retries(
+            self.llm, messages, self.max_retries
+        )
+
+    def _generate_code_with_retries(
+        self,
+        chat_model: BaseChatModel,
+        messages: List[BaseMessage],
+        retries: int = 3,
+    ) -> str:
+        response = chat_model.predict_messages(messages)
+        if self.logger is not None:
+            self.logger.info(response.content)
+        code = AIUtils.extract_code_blocks(response.content)[0]
+        try:
+            self.spark.sql(code)
+            return code
+        except Exception as e:
+            if self.logger is not None:
+                self.logger.warning("Getting the following error: \n" + str(e))
+            if retries <= 0:
+                # if we have no more retries, raise the exception
+                self.logger.info(
+                    "No more retries left, please modify the instruction or modify the generated code"
+                )
+                return ""
+            if self.logger is not None:
+                self.logger.info("Retrying with " + str(retries) + " retries left")
+
+            messages.append(response)
+            # append the exception as a HumanMessage into messages
+            messages.append(HumanMessage(content=str(e)))
+            return self._generate_code_with_retries(
+                chat_model, messages, retries - 1
+            )

--- a/pyspark_ai/spark_sql_chain.py
+++ b/pyspark_ai/spark_sql_chain.py
@@ -15,6 +15,7 @@ class SparkSQLChain(LLMChain):
     LLM Chain for generating SQL code for DataFrame transform.
     It supports retrying if the generated query fails the SQL compiler.
     """
+
     spark: SparkSession
     logger: CodeLogger = None
     max_retries: int = 3
@@ -33,9 +34,7 @@ class SparkSQLChain(LLMChain):
         ), "The llm is not an instance of BaseChatModel"
         prompt_str = self.prompt.format_prompt(**kwargs).to_string()
         messages = [HumanMessage(content=prompt_str)]
-        return self._generate_code_with_retries(
-            self.llm, messages, self.max_retries
-        )
+        return self._generate_code_with_retries(self.llm, messages, self.max_retries)
 
     def _generate_code_with_retries(
         self,
@@ -65,6 +64,4 @@ class SparkSQLChain(LLMChain):
             messages.append(response)
             # append the exception as a HumanMessage into messages
             messages.append(HumanMessage(content=str(e)))
-            return self._generate_code_with_retries(
-                chat_model, messages, retries - 1
-            )
+            return self._generate_code_with_retries(chat_model, messages, retries - 1)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -6,6 +6,7 @@ from typing import List
 
 import numpy as np
 from chispa.dataframe_comparer import assert_df_equality
+from langchain.chat_models import ChatOpenAI
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import expr, lit, mean, stddev
 from pyspark.sql.types import ArrayType, DoubleType, StringType
@@ -20,77 +21,21 @@ from benchmark.wikisql.wiki_sql import (
     os.environ.get("OPENAI_API_KEY") and os.environ["OPENAI_API_KEY"].strip() != "",
     "OPENAI_API_KEY is not set",
 )
-class EndToEndTestCase(unittest.TestCase):
-    def setUp(self):
-        self.spark_ai = SparkAI()
+class EndToEndTestCaseGPT35(unittest.TestCase):
+    def setup_spark_ai(self, spark: SparkSession):
+        self.spark_ai = SparkAI(llm=ChatOpenAI(model_name="gpt-3.5-turbo"))
         self.spark_ai.activate()
+
+    def setUp(self):
         self.spark = (
             SparkSession.builder.master("local[*]")
             .appName("End2end-tests")
             .getOrCreate()
         )
-
-        # Generate heterogeneous JSON by randomly reorder list of keys and drop some of them
-        random_dict = {
-            "id": 1279,
-            "first_name": "John",
-            "last_name": "Doe",
-            "username": "johndoe",
-            "email": "john_doe@example.com",
-            "phone_number": "+1 234 567 8900",
-            "address": "123 Main St, Springfield, OH, 45503, USA",
-            "age": 32,
-            "registration_date": "2020-01-20T12:12:12Z",
-            "last_login": "2022-03-21T07:25:34Z",
-        }
-        self.json_keys = list(random_dict.keys())
-        rows = []
-        for _ in range(20):
-            keys = [k for k in random_dict.keys()]
-            shuffle(keys)
-            rows.append({k: random_dict[k] for k in keys if random() <= 0.6})
-
-        self.bad_json = self.spark.createDataFrame(
-            [(json.dumps(val), self.json_keys) for val in rows],
-            ["json_field", "schema"],
-        )
-        # Generate expected output of parsed JSON: list of fields in a right order or null if field is missing
-        self.expected_output = self.spark.createDataFrame(
-            [
-                (
-                    json.dumps(val),
-                    self.json_keys,
-                    [val.get(k, None) for k in self.json_keys],
-                )
-                for val in rows
-            ],
-            ["json_field", "schema", "parsed"],
-        )
-
-        # Add a DataFrame with random texts that contain emails
-        self.email_df = self.spark.createDataFrame(
-            [
-                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed egestas nulla sit amet elit volutpat ultricies. Morbi lacinia est fringilla pulvinar elementum. Curabitur rhoncus luctus dui, sodales blandit arcu maximus a. Aenean iaculis nulla ac enim tincidunt, et tristique enim bibendum. Fusce mollis nibh sit amet nisi pellentesque egestas. Quisque volutpat, neque eu semper tristique, odio nunc auctor odio, at condimentum lorem nunc nec nisi. Quisque auctor at velit nec fermentum. Nunc id pellentesque erat, et dignissim felis. ali.brown@gmail.com Suspendisse potenti. Donec tincidunt enim in ipsum faucibus sollicitudin. Sed placerat tempor eros at blandit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec aliquam velit vehicula massa egestas faucibus. Ut pulvinar mi id pretium dignissim. Phasellus vehicula, dui sit amet porttitor effectively maximizes an attacker's chance to obtain valid credentials. Sed malesuada justo enim, et interdum mauris ullamcorper ac.",
-                "Vestibulum rhoncus magna semper est lobortis gravida. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In hac habitasse platea dictumst. michael.hobb@gmail.com Aenean sapien magna, consequat vitae pretium ac, gravida sit amet nibh. Maecenas lacinia orci in luctus placerat. Praesent lobortis turpis nec risus dapibus, eget ornare mi egestas. Nam eget dui ac mi laoreet sagittis. Integer condimentum est ac velit volutpat pharetra. Nulla facilisi. Nunc euismod, neque vitae porttitor maximus, justo dui efficitur ligula, vitae tincidunt erat neque ac nibh. Duis eu dui in erat blandit mattis.",
-                "Aenean vitae iaculis odio. Donec laoreet non urna sed posuere. Nulla vitae orci finibus, convallis mauris nec, mattis augue. Proin bibendum non justo non scelerisque. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Aenean scott_p@ymail.com adipiscing diam eget ultrices ultricies. Aliquam bibendum dolor vel orci posuere, sed pulvinar enim rutrum. Nulla facilisi. Sed cursus justo sed velit pharetra auctor. Suspendisse facilisis nibh id nibh ultrices luctus.",
-                "Quisque varius erat sed leo ornare, et elementum leo interdum. Aliquam erat volutpat. Ut laoreet tempus elit quis venenatis. Integer porta, lorem ut pretium luctus, erika.23@hotmail.com quis ipsum facilisis, feugiat libero sed, malesuada augue. Fusce id elementum sapien, sed SC ingeniously maximizes the chance to obtain valid credentials. Nullam imperdiet felis in metus semper ultrices. Integer vel quam consectetur, lobortis est vitae, lobortis sem. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.",
-                "Sed consectetur nisl quis mauris laoreet posuere. Phasellus in elementum orci, vitae auctor dui. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Donec eleifend mauris id auctor blandit. john.smith@protonmail.com Integer quis justo non eros convallis aliquet cursus eu dolor. Praesent nec sem a massa facilisis consectetur. Nunc pharetra sapien non erat semper, ut tempus risus vulputate. Donec lacinia condimentum arcu, ac molestie metus interdum in. Duis arcu quam, hendrerit quis venenatis sed, porta at erat.",
-            ],
-            schema="string",
-        )
-        self.parsed_email_df = self.spark.createDataFrame(
-            [
-                "ali.brown@gmail.com",
-                "michael.hobb@gmail.com",
-                "scott_p@ymail.com",
-                "erika.23@hotmail.com",
-                "john.smith@protonmail.com",
-            ],
-            schema="string",
-        )
+        self.setup_spark_ai(self.spark)
 
     def create_and_get_table_name(
-        self, table: str, table_file: str = "tests/data/test_transform_e2e.tables.jsonl"
+        self, table: str, table_file: str = "data/test_transform_e2e.tables.jsonl"
     ):
         """Util function to create temp view for desired table and return the table name"""
         statements = create_temp_view_statements(table_file)
@@ -156,6 +101,84 @@ class EndToEndTestCase(unittest.TestCase):
         finally:
             self.spark.sql(f"DROP TABLE IF EXISTS {table_name}")
 
+
+    def test_plot(self):
+        flight_df = self.spark_ai._spark.read.option("header", "true").csv("data/2011_february_aa_flight_paths.csv")
+        # The following plotting will probably fail on the first run with error:
+        #     'DataFrame' object has no attribute 'date'
+        code = flight_df.ai.plot("Boxplot summarizing the range of starting latitudes for all AA flights in February 2011.")
+        assert(code != "")
+
+
+class EndToEndTestCaseGPT4(EndToEndTestCaseGPT35):
+    def setup_spark_ai(self, spark: SparkSession):
+        self.spark_ai = SparkAI(llm=ChatOpenAI(model_name="gpt-4"))
+        self.spark_ai.activate()
+
+    def setUp(self):
+        super().setUp()
+        # Generate heterogeneous JSON by randomly reorder list of keys and drop some of them
+        random_dict = {
+            "id": 1279,
+            "first_name": "John",
+            "last_name": "Doe",
+            "username": "johndoe",
+            "email": "john_doe@example.com",
+            "phone_number": "+1 234 567 8900",
+            "address": "123 Main St, Springfield, OH, 45503, USA",
+            "age": 32,
+            "registration_date": "2020-01-20T12:12:12Z",
+            "last_login": "2022-03-21T07:25:34Z",
+        }
+        self.json_keys = list(random_dict.keys())
+        rows = []
+        for _ in range(20):
+            keys = [k for k in random_dict.keys()]
+            shuffle(keys)
+            rows.append({k: random_dict[k] for k in keys if random() <= 0.6})
+
+        self.bad_json = self.spark.createDataFrame(
+            [(json.dumps(val), self.json_keys) for val in rows],
+            ["json_field", "schema"],
+        )
+        # Generate expected output of parsed JSON: list of fields in a right order or null if field is missing
+        self.expected_output = self.spark.createDataFrame(
+            [
+                (
+                    json.dumps(val),
+                    self.json_keys,
+                    [val.get(k, None) for k in self.json_keys],
+                )
+                for val in rows
+            ],
+            ["json_field", "schema", "parsed"],
+        )
+
+        # Add a DataFrame with random texts that contain emails
+        self.email_df = self.spark.createDataFrame(
+            [
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed egestas nulla sit amet elit volutpat ultricies. Morbi lacinia est fringilla pulvinar elementum. Curabitur rhoncus luctus dui, sodales blandit arcu maximus a. Aenean iaculis nulla ac enim tincidunt, et tristique enim bibendum. Fusce mollis nibh sit amet nisi pellentesque egestas. Quisque volutpat, neque eu semper tristique, odio nunc auctor odio, at condimentum lorem nunc nec nisi. Quisque auctor at velit nec fermentum. Nunc id pellentesque erat, et dignissim felis. ali.brown@gmail.com Suspendisse potenti. Donec tincidunt enim in ipsum faucibus sollicitudin. Sed placerat tempor eros at blandit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec aliquam velit vehicula massa egestas faucibus. Ut pulvinar mi id pretium dignissim. Phasellus vehicula, dui sit amet porttitor effectively maximizes an attacker's chance to obtain valid credentials. Sed malesuada justo enim, et interdum mauris ullamcorper ac.",
+                "Vestibulum rhoncus magna semper est lobortis gravida. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In hac habitasse platea dictumst. michael.hobb@gmail.com Aenean sapien magna, consequat vitae pretium ac, gravida sit amet nibh. Maecenas lacinia orci in luctus placerat. Praesent lobortis turpis nec risus dapibus, eget ornare mi egestas. Nam eget dui ac mi laoreet sagittis. Integer condimentum est ac velit volutpat pharetra. Nulla facilisi. Nunc euismod, neque vitae porttitor maximus, justo dui efficitur ligula, vitae tincidunt erat neque ac nibh. Duis eu dui in erat blandit mattis.",
+                "Aenean vitae iaculis odio. Donec laoreet non urna sed posuere. Nulla vitae orci finibus, convallis mauris nec, mattis augue. Proin bibendum non justo non scelerisque. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Aenean scott_p@ymail.com adipiscing diam eget ultrices ultricies. Aliquam bibendum dolor vel orci posuere, sed pulvinar enim rutrum. Nulla facilisi. Sed cursus justo sed velit pharetra auctor. Suspendisse facilisis nibh id nibh ultrices luctus.",
+                "Quisque varius erat sed leo ornare, et elementum leo interdum. Aliquam erat volutpat. Ut laoreet tempus elit quis venenatis. Integer porta, lorem ut pretium luctus, erika.23@hotmail.com quis ipsum facilisis, feugiat libero sed, malesuada augue. Fusce id elementum sapien, sed SC ingeniously maximizes the chance to obtain valid credentials. Nullam imperdiet felis in metus semper ultrices. Integer vel quam consectetur, lobortis est vitae, lobortis sem. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.",
+                "Sed consectetur nisl quis mauris laoreet posuere. Phasellus in elementum orci, vitae auctor dui. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Donec eleifend mauris id auctor blandit. john.smith@protonmail.com Integer quis justo non eros convallis aliquet cursus eu dolor. Praesent nec sem a massa facilisis consectetur. Nunc pharetra sapien non erat semper, ut tempus risus vulputate. Donec lacinia condimentum arcu, ac molestie metus interdum in. Duis arcu quam, hendrerit quis venenatis sed, porta at erat.",
+            ],
+            schema="string",
+        )
+        self.parsed_email_df = self.spark.createDataFrame(
+            [
+                "ali.brown@gmail.com",
+                "michael.hobb@gmail.com",
+                "scott_p@ymail.com",
+                "erika.23@hotmail.com",
+                "john.smith@protonmail.com",
+            ],
+            schema="string",
+        )
+
+
+    # The following tests are skipped for gpt-3.5-turbo because they can be flaky
+    # Also, our current focus is on DataFrame transform and plotting.
     def test_array_udf_output(self):
         @self.spark_ai.udf
         def parse_heterogeneous_json(json_str: str, schema: List[str]) -> List[str]:
@@ -212,10 +235,3 @@ class EndToEndTestCase(unittest.TestCase):
 
         assert abs(spark_results["mean"] - numpy_mean) / numpy_mean <= 0.05
         assert abs(spark_results["stddev"] - numpy_stddev) / numpy_stddev <= 0.05
-
-    def test_plot(self):
-        flight_df = self.spark_ai._spark.read.option("header", "true").csv("tests/data/2011_february_aa_flight_paths.csv")
-        # The following plotting will probably fail on the first run with error:
-        #     'DataFrame' object has no attribute 'date'
-        code = flight_df.ai.plot("Boxplot summarizing the range of starting latitudes for all AA flights in February 2011.")
-        assert(code != "")

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -35,7 +35,7 @@ class EndToEndTestCaseGPT35(unittest.TestCase):
         self.setup_spark_ai(self.spark)
 
     def create_and_get_table_name(
-        self, table: str, table_file: str = "data/test_transform_e2e.tables.jsonl"
+        self, table: str, table_file: str = "tests/data/test_transform_e2e.tables.jsonl"
     ):
         """Util function to create temp view for desired table and return the table name"""
         statements = create_temp_view_statements(table_file)
@@ -103,7 +103,7 @@ class EndToEndTestCaseGPT35(unittest.TestCase):
 
 
     def test_plot(self):
-        flight_df = self.spark_ai._spark.read.option("header", "true").csv("data/2011_february_aa_flight_paths.csv")
+        flight_df = self.spark_ai._spark.read.option("header", "true").csv("tests/data/2011_february_aa_flight_paths.csv")
         # The following plotting will probably fail on the first run with error:
         #     'DataFrame' object has no attribute 'date'
         code = flight_df.ai.plot("Boxplot summarizing the range of starting latitudes for all AA flights in February 2011.")


### PR DESCRIPTION
Currently, the SDK is using a ReAct agent for DataFrame transform, which requires the output format to be of the following format:
![sql](https://github.com/pyspark-ai/pyspark-ai/assets/1097932/99da6cd1-7f7d-4495-8e4b-0b35c6559b5f)

```

Thought: Spark SQL does not support dynamic pivot operations, which are required to transpose the table as requested. I should get all the distinct values of column product.
Action: query_sql_db
Action Input: "SELECT DISTINCT product FROM spark_ai_temp_view_096b0f"
Observation: [('Normal',), ('Mini',), ('Foldable',), ('Pro',), ('Pro Max',)]
```

This doesn't work well when the LLM is not GPT-4. From time to time, there can be parse exceptions. For example: https://github.com/pyspark-ai/pyspark-ai/issues/118

So, to make sure the API `df.ai.transform` generate robust code on non-gpt-4 models, we can follow https://github.com/pyspark-ai/pyspark-ai/pull/159 and implement SQL generator which supports auto-retry on errors:
![image](https://github.com/pyspark-ai/pyspark-ai/assets/1097932/cf189f9c-bdc4-4c99-9188-ee103dce5b57)

