### PR TITLE
Skip test for transform without similar_value

### DIFF
--- a/tests/test_ai_tools.py
+++ b/tests/test_ai_tools.py
@@ -336,7 +336,7 @@ class TestSimilarValueTool(unittest.TestCase):
 
             self.assertTrue("already exceeds max directory size" in e.exception)
 
-    @unittest.skip("skip test due to non-deterministic behavior")
+    @unittest.skip("skip test due to nondeterministic behavior")
     def test_transform_without_similar_value_tool(self):
         """Test that agent does not try to access SimilarValueTool if it is disabled"""
         spark_ai = SparkAI()

--- a/tests/test_ai_tools.py
+++ b/tests/test_ai_tools.py
@@ -336,10 +336,7 @@ class TestSimilarValueTool(unittest.TestCase):
 
             self.assertTrue("already exceeds max directory size" in e.exception)
 
-    @unittest.skipUnless(
-        os.environ.get("OPENAI_API_KEY") and os.environ["OPENAI_API_KEY"].strip() != "",
-        "OPENAI_API_KEY is not set",
-    )
+    @unittest.skip("skip test due to non-deterministic behavior")
     def test_transform_without_similar_value_tool(self):
         """Test that agent does not try to access SimilarValueTool if it is disabled"""
         spark_ai = SparkAI()


### PR DESCRIPTION
This PR skips `test_transform_without_similar_value_tool` (nondeterministic behavior) for later investigation