### PR TITLE
Ignore end-to-end test case test_array_udf_output 

### DIFF
--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -177,6 +177,7 @@ class EndToEndTestCaseGPT4(EndToEndTestCaseGPT35):
 
     # The following tests are skipped for gpt-3.5-turbo because they can be flaky
     # Also, our current focus is on DataFrame transform and plotting.
+    @unittest.skip("skip test due to nondeterministic behavior")
     def test_array_udf_output(self):
         @self.spark_ai.udf
         def parse_heterogeneous_json(json_str: str, schema: List[str]) -> List[str]:


### PR DESCRIPTION
The test case test_array_udf_output becomes unstable as per https://github.com/pyspark-ai/pyspark-ai/actions/runs/6724764580/job/18277726463