### PR TITLE
Bump version to v0.1.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyspark-ai"
-version = "0.1.17"
+version = "0.1.19"
 description = "English SDK for Apache Spark"
 authors = ["Gengliang Wang <gengliang@apache.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
We restore v0.1.16 as v0.1.18 in the previous release.
With many enhancement in the latest master, it is time to release v0.1.19