### PR TITLE
Add API docs generation

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Install poetry
         run: |
           pipx install "poetry>=1.3.0,<1.4.0"
-      - run: poetry install --only website
+      # Because generating of API docs requires actual import of all the files
+      # we need to install all the dependencies that are used in the project.
+      - run: poetry install --with website --extras all
       - run: poetry run mkdocs gh-deploy --force
 

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ coverage.xml
 
 # Emacs things
 .dir-locals.el
+
+# Website
+site/

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -4,9 +4,16 @@
 # https://mkdocstrings.github.io/recipes/#automatic-code-reference-pages
 
 
+from __future__ import annotations
+
 from pathlib import Path
 
 import mkdocs_gen_files
+
+WHITELIST: tuple[str, ...] = (
+    "pyspark_ai",
+    "ai_utils",
+)
 
 nav = mkdocs_gen_files.Nav()
 
@@ -21,7 +28,7 @@ for path in sorted(Path(".").rglob("pyspark_ai/**/*.py")):
         parts = parts[:-1]
         doc_path = doc_path.with_name("index.md")
         full_doc_path = full_doc_path.with_name("index.md")
-    elif parts[-1] == "__main__":
+    elif parts[-1] not in WHITELIST:
         continue
 
     nav[parts] = doc_path.as_posix()  #

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -1,0 +1,36 @@
+# This code is heavily inspired by https://github.com/MrPowers/quinn/blob/main/docs/gen_ref_pages.py
+#
+# An implementation in Quinn is inspired by the documentation of mkdocstrings
+# https://mkdocstrings.github.io/recipes/#automatic-code-reference-pages
+
+
+from pathlib import Path
+
+import mkdocs_gen_files
+
+nav = mkdocs_gen_files.Nav()
+
+for path in sorted(Path(".").rglob("pyspark_ai/**/*.py")):
+    module_path = path.relative_to(".").with_suffix("")
+    doc_path = path.relative_to(".").with_suffix(".md")
+    full_doc_path = Path("reference", doc_path)
+
+    parts = tuple(module_path.parts)
+
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+        doc_path = doc_path.with_name("index.md")
+        full_doc_path = full_doc_path.with_name("index.md")
+    elif parts[-1] == "__main__":
+        continue
+
+    nav[parts] = doc_path.as_posix()  #
+
+    with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+        ident = ".".join(parts)
+        fd.write(f"::: {ident}")
+
+    mkdocs_gen_files.set_edit_path(full_doc_path, path)
+
+with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
+    nav_file.writelines(nav.build_literate_nav())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,9 +24,22 @@ nav:
       - "notebooks/transform_dataframe.ipynb"
       - "notebooks/create_udf.ipynb"
       - "notebooks/vector_similarity_search.ipynb"
+  - API Reference: reference/SUMMARY.md
 
 plugins:
   - mkdocs-jupyter
+  - gen-files:
+      scripts:
+        - docs/gen_ref_pages.py
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          options:
+            docstring_style: sphinx
+            docstring_options:
+              show_if_no_docstring: true
+            show_source: true
 
 # Extensions
 markdown_extensions:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1025,6 +1025,20 @@ docs = ["Sphinx", "furo"]
 test = ["objgraph", "psutil"]
 
 [[package]]
+name = "griffe"
+version = "0.45.2"
+description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "griffe-0.45.2-py3-none-any.whl", hash = "sha256:297ec8530d0c68e5b98ff86fb588ebc3aa3559bb5dc21f3caea8d9542a350133"},
+    {file = "griffe-0.45.2.tar.gz", hash = "sha256:83ce7dcaafd8cb7f43cbf1a455155015a1eb624b1ffd93249e5e1c4a22b2fdb2"},
+]
+
+[package.dependencies]
+colorama = ">=0.4"
+
+[[package]]
 name = "grpcio"
 version = "1.63.0"
 description = "HTTP/2-based RPC framework"
@@ -1867,6 +1881,36 @@ i18n = ["babel (>=2.9.0)"]
 min-versions = ["babel (==2.9.0)", "click (==7.0)", "colorama (==0.4)", "ghp-import (==1.0)", "importlib-metadata (==4.4)", "jinja2 (==2.11.1)", "markdown (==3.3.6)", "markupsafe (==2.0.1)", "mergedeep (==1.3.4)", "mkdocs-get-deps (==0.2.0)", "packaging (==20.5)", "pathspec (==0.11.1)", "pyyaml (==5.1)", "pyyaml-env-tag (==0.1)", "watchdog (==2.0)"]
 
 [[package]]
+name = "mkdocs-autorefs"
+version = "1.0.1"
+description = "Automatically link across pages in MkDocs."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mkdocs_autorefs-1.0.1-py3-none-any.whl", hash = "sha256:aacdfae1ab197780fb7a2dac92ad8a3d8f7ca8049a9cbe56a4218cd52e8da570"},
+    {file = "mkdocs_autorefs-1.0.1.tar.gz", hash = "sha256:f684edf847eced40b570b57846b15f0bf57fb93ac2c510450775dcf16accb971"},
+]
+
+[package.dependencies]
+Markdown = ">=3.3"
+markupsafe = ">=2.0.1"
+mkdocs = ">=1.1"
+
+[[package]]
+name = "mkdocs-gen-files"
+version = "0.5.0"
+description = "MkDocs plugin to programmatically generate documentation pages during the build"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mkdocs_gen_files-0.5.0-py3-none-any.whl", hash = "sha256:7ac060096f3f40bd19039e7277dd3050be9a453c8ac578645844d4d91d7978ea"},
+    {file = "mkdocs_gen_files-0.5.0.tar.gz", hash = "sha256:4c7cf256b5d67062a788f6b1d035e157fc1a9498c2399be9af5257d4ff4d19bc"},
+]
+
+[package.dependencies]
+mkdocs = ">=1.0.3"
+
+[[package]]
 name = "mkdocs-get-deps"
 version = "0.2.0"
 description = "MkDocs extension that lists all dependencies according to a mkdocs.yml file"
@@ -1900,6 +1944,20 @@ mkdocs = ">=1.4.0,<2"
 mkdocs-material = ">9.0.0"
 nbconvert = ">=7.2.9,<8"
 pygments = ">2.12.0"
+
+[[package]]
+name = "mkdocs-literate-nav"
+version = "0.6.1"
+description = "MkDocs plugin to specify the navigation in Markdown instead of YAML"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mkdocs_literate_nav-0.6.1-py3-none-any.whl", hash = "sha256:e70bdc4a07050d32da79c0b697bd88e9a104cf3294282e9cb20eec94c6b0f401"},
+    {file = "mkdocs_literate_nav-0.6.1.tar.gz", hash = "sha256:78a7ab6d878371728acb0cdc6235c9b0ffc6e83c997b037f4a5c6ff7cef7d759"},
+]
+
+[package.dependencies]
+mkdocs = ">=1.0.3"
 
 [[package]]
 name = "mkdocs-material"
@@ -1940,6 +1998,49 @@ files = [
     {file = "mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31"},
     {file = "mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443"},
 ]
+
+[[package]]
+name = "mkdocstrings"
+version = "0.25.1"
+description = "Automatic documentation from sources, for MkDocs."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mkdocstrings-0.25.1-py3-none-any.whl", hash = "sha256:da01fcc2670ad61888e8fe5b60afe9fee5781017d67431996832d63e887c2e51"},
+    {file = "mkdocstrings-0.25.1.tar.gz", hash = "sha256:c3a2515f31577f311a9ee58d089e4c51fc6046dbd9e9b4c3de4c3194667fe9bf"},
+]
+
+[package.dependencies]
+click = ">=7.0"
+importlib-metadata = {version = ">=4.6", markers = "python_version < \"3.10\""}
+Jinja2 = ">=2.11.1"
+Markdown = ">=3.3"
+MarkupSafe = ">=1.1"
+mkdocs = ">=1.4"
+mkdocs-autorefs = ">=0.3.1"
+platformdirs = ">=2.2.0"
+pymdown-extensions = ">=6.3"
+typing-extensions = {version = ">=4.1", markers = "python_version < \"3.10\""}
+
+[package.extras]
+crystal = ["mkdocstrings-crystal (>=0.3.4)"]
+python = ["mkdocstrings-python (>=0.5.2)"]
+python-legacy = ["mkdocstrings-python-legacy (>=0.2.1)"]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "1.10.3"
+description = "A Python handler for mkdocstrings."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mkdocstrings_python-1.10.3-py3-none-any.whl", hash = "sha256:11ff6d21d3818fb03af82c3ea6225b1534837e17f790aa5f09626524171f949b"},
+    {file = "mkdocstrings_python-1.10.3.tar.gz", hash = "sha256:321cf9c732907ab2b1fedaafa28765eaa089d89320f35f7206d00ea266889d03"},
+]
+
+[package.dependencies]
+griffe = ">=0.44"
+mkdocstrings = ">=0.25"
 
 [[package]]
 name = "mkl"
@@ -4609,4 +4710,4 @@ vector-search = ["faiss-cpu", "sentence-transformers", "torch"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "affd19cccd27300c8569de102d65bcc4d621f65110850aa7cd101fe882b7ab56"
+content-hash = "0671c425ec7696030001a88c1bcbe7f5414de33280b4030b9658d35d05c6a130"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ black = "^23.7"
 [tool.poetry.group.website.dependencies]
 mkdocs-material = "^9"
 mkdocs-jupyter = "^0"
+mkdocstrings-python = "*"
+mkdocs-gen-files = "*"
+mkdocs-literate-nav = "*"
 
 [tool.poetry.extras]
 plot = ["pandas", "plotly", "pyarrow"]


### PR DESCRIPTION
 On branch api-docs-generation
 Changes to be committed:
	modified:   .github/workflows/website.yml
	modified:   .gitignore
	new file:   docs/gen_ref_pages.py
	modified:   mkdocs.yml
	modified:   poetry.lock
	modified:   pyproject.toml


Close #83


This PR includes the following changes:
1. Update dependencies as discussed [here](https://github.com/pyspark-ai/pyspark-ai/issues/83#issuecomment-1742064246)
2. Add generation file as discussed in the same comment
3. Update mkdocs.yaml
4. **Update site-workflow by including all the dependencies** (see commentary in the code)

I made a deployment from my fork and it looks like this:
https://semyonsinchenko.github.io/pyspark-ai/reference/SUMMARY/